### PR TITLE
Update electron only

### DIFF
--- a/src/widgetron/__init__.py
+++ b/src/widgetron/__init__.py
@@ -1,1 +1,1 @@
-VERSION = "0.1.9"
+VERSION = "0.2.0"

--- a/src/widgetron/templates/electron/package.json_template
+++ b/src/widgetron/templates/electron/package.json_template
@@ -23,11 +23,11 @@
     }
   },
   "devDependencies": {
-    "@cyclonedx/cyclonedx-npm": "^1.9.2",
-    "electron": "^22.3.1",
-    "electron-builder": "^23.6.0"
+    "@cyclonedx/cyclonedx-npm": ">=1.9.2",
+    "electron": ">=25",
+    "electron-builder": ">=24"
   },
   "dependencies": {
-    "electron-store": "^8.1.0"
+    "electron-store": ">=8.1.0"
   }
 }


### PR DESCRIPTION
Electron was not previously updating past version 24 because of a misunderstanding of `^` behavior