### PR TITLE
Company hotfix

### DIFF
--- a/src/widgetron/__init__.py
+++ b/src/widgetron/__init__.py
@@ -1,1 +1,1 @@
-VERSION = "0.2.5"
+VERSION = "0.2.6"

--- a/src/widgetron/utils/settings.py
+++ b/src/widgetron/utils/settings.py
@@ -36,6 +36,7 @@ class ConstructorSettings(T.HasTraits):
     environment_file: str | None = T.Unicode(None, allow_none=True)
     environment: str | None = T.Unicode(None, allow_none=True)
 
+    company: str | None = T.Unicode(None, allow_none=True)
     installer_filename: str | None = T.Unicode(None, allow_none=True)
     header_image_text: str | None = T.Unicode(None, allow_none=True)
     default_image_color: str | None = T.Unicode(None, allow_none=True)

--- a/src/widgetron/utils/settings.py
+++ b/src/widgetron/utils/settings.py
@@ -37,6 +37,7 @@ class ConstructorSettings(T.HasTraits):
     environment: str | None = T.Unicode(None, allow_none=True)
 
     company: str | None = T.Unicode(None, allow_none=True)
+    license_file: str | None = T.Unicode(None, allow_none=True)
     installer_filename: str | None = T.Unicode(None, allow_none=True)
     header_image_text: str | None = T.Unicode(None, allow_none=True)
     default_image_color: str | None = T.Unicode(None, allow_none=True)
@@ -236,6 +237,7 @@ class ConstructorSettings(T.HasTraits):
         "environment_yaml",
         "explicit_lock",
         "environment_file",
+        "license_file",
     )
     def _ensure_file_exists(self, proposal: T.Bunch):
         p = Path(proposal["value"])


### PR DESCRIPTION
Enables the passthrough of some constructor variables `company` and `license_file`