### PR TITLE
Electron datapath

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 
 dependencies:
-  - boa >=0.15.1
+  - boa ==0.15.1 # https://github.com/mamba-org/boa/issues/388
   - constructor >=3.4.5
   - nodejs >18, <19
   - python <=3.11

--- a/src/widgetron/__main__.py
+++ b/src/widgetron/__main__.py
@@ -114,6 +114,9 @@ def package_electron_app(kwargs):
 
         SHELL.call([NPM, "run", "build"])
 
+        env = os.environ
+        env.update(**{"FETCH_LICENSE": "1"})
+
         if not kwargs["skip_sbom"]:
             sbom = Path(kwargs["outdir"]) / "npm-sbom.json"
             cmd = [
@@ -126,7 +129,7 @@ def package_electron_app(kwargs):
                 "--output-file",
                 f"{sbom}",
             ]
-            SHELL.call(cmd)
+            SHELL.call(cmd, env=env)
 
         if OSX or LINUX:
             dist = "dist"

--- a/src/widgetron/__main__.py
+++ b/src/widgetron/__main__.py
@@ -115,7 +115,7 @@ def package_electron_app(kwargs):
         SHELL.call([NPM, "run", "build"])
 
         env = os.environ
-        env.update(**{"FETCH_LICENSE": "1"})
+        env["FETCH_LICENSE"] = "1"
 
         if not kwargs["skip_sbom"]:
             sbom = Path(kwargs["outdir"]) / "npm-sbom.json"

--- a/src/widgetron/templates/electron/main.js_template
+++ b/src/widgetron/templates/electron/main.js_template
@@ -1,8 +1,8 @@
 const { app, BrowserWindow, shell } = require('electron')
 const fs = require("fs")
 
-url = process.env.widgetron_url;
-appdata = process.env.widgetron_appdata.replace("\\", "/");
+url = process.env.WIDGETRON_URL;
+appdata = process.env.WIDGETRON_APPDATA.replace("\\", "/");
 url_whitelist = [
 {%- for url in url_whitelist %}
   "{{url}}",

--- a/src/widgetron/templates/electron/main.js_template
+++ b/src/widgetron/templates/electron/main.js_template
@@ -1,9 +1,9 @@
-const { app, BrowserWindow } = require('electron')
+const { app, BrowserWindow, shell} = require('electron')
 const Config = require('electron-store')
 const config = new Config()
-const { shell } = require('electron')
 
 url = process.env.widgetron_url;
+appdata = process.env.widgetron_appdata;
 url_whitelist = [
 {%- for url in url_whitelist %}
   "{{url}}",
@@ -18,6 +18,7 @@ domain_whitelist = [
 
 // https://www.electronjs.org/docs/latest/tutorial/sandbox#enabling-the-sandbox-globally
 app.enableSandbox();  // Force sandboxing
+app.setPath("appData", appdata)
 
 app.on('web-contents-created', (event, contents) => {
   

--- a/src/widgetron/templates/electron/main.js_template
+++ b/src/widgetron/templates/electron/main.js_template
@@ -1,9 +1,8 @@
-const { app, BrowserWindow, shell} = require('electron')
-const Config = require('electron-store')
-const config = new Config()
+const { app, BrowserWindow, shell } = require('electron')
+const fs = require("fs")
 
 url = process.env.widgetron_url;
-appdata = process.env.widgetron_appdata;
+appdata = process.env.widgetron_appdata.replace("\\", "/");
 url_whitelist = [
 {%- for url in url_whitelist %}
   "{{url}}",
@@ -14,6 +13,12 @@ domain_whitelist = [
   "{{domain}}",
 {%- endfor %}
 ]
+
+try {
+  config = JSON.parse(fs.readFileSync(`${appdata}/widgetron/config.json`))
+} catch {
+  config = {}
+}
 
 
 // https://www.electronjs.org/docs/latest/tutorial/sandbox#enabling-the-sandbox-globally
@@ -62,14 +67,18 @@ app.whenReady().then(() => {
     }
   }
   const win = new BrowserWindow(opts);
+
+  if (config.winBounds != undefined) {
+    win.setBounds(config.winBounds)
+  }
   
-  win.setBounds(config.get('winBounds'))
   if (url.startsWith("http://localhost:")) {
     win.loadURL(url);
   }
 
   win.on('close', function(e) {
-    config.set('winBounds', win.getBounds())
+    config.winBounds = win.getBounds()
+    fs.writeFileSync(`${appdata}/widgetron/config.json`, JSON.stringify(config))
     e.preventDefault();
     win.destroy();
   });

--- a/src/widgetron/templates/electron/package.json_template
+++ b/src/widgetron/templates/electron/package.json_template
@@ -26,8 +26,5 @@
     "@cyclonedx/cyclonedx-npm": ">=1.9.2",
     "electron": "{{electron_version}}",
     "electron-builder": "{{electron_builder_version}}"
-  },
-  "dependencies": {
-    "electron-store": ">=8.1.0"
   }
 }

--- a/src/widgetron/templates/server/widgetron_app/cli.py_template
+++ b/src/widgetron/templates/server/widgetron_app/cli.py_template
@@ -1,5 +1,6 @@
 import os
 import platform
+import sys
 import psutil
 import re
 import subprocess
@@ -14,10 +15,15 @@ ARGS = [{% for part in server_command_args %}'{{part}}',{% endfor %}]
 HERE = Path(__file__).parent
 
 os.chdir(str(HERE))
+env = os.environ
 #: Help Jupyter ignore other .jupyter config paths
-os.environ["JUPYTER_PREFER_ENVIRONMENT_OVER_USER"] = "1"
+env["JUPYTER_PREFER_ENVIRONMENT_OVER_USER"] = "1"
 #: Silence warning about frozen modules
-os.environ["PYDEVD_DISABLE_FILE_VALIDATION"]="1"
+env["PYDEVD_DISABLE_FILE_VALIDATION"]="1"
+# Set app data location for the electron configuration settings
+appdata = Path(sys.prefix) / "etc"
+appdata.mkdir(exist_ok=True)
+env["widgetron_appdata"] = str(appdata)
 
 SYS = platform.uname().system
 if SYS == "Windows":
@@ -42,7 +48,8 @@ class Server:
             [command, *ARGS,],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            text=True
+            text=True,
+            env=env,
         )
         self.process = psutil.Process(self.server.pid)
         self.url = None
@@ -78,7 +85,7 @@ def main():
     server = Server()
 
     url = f"http://localhost:{server.port}/lab/tree/{FILENAME}?token={server.token}"
-    os.environ["widgetron_url"] = url
+    env["widgetron_url"] = url
 
     # open UI
     if SYS == "Darwin":
@@ -88,5 +95,5 @@ def main():
     if SYS == "Windows":
         UI = str(next(HERE.rglob("widgetron.exe")).resolve())
     
-    subprocess.call(UI)
+    subprocess.call(UI, env=env)
     server.stop()

--- a/src/widgetron/templates/server/widgetron_app/cli.py_template
+++ b/src/widgetron/templates/server/widgetron_app/cli.py_template
@@ -14,16 +14,17 @@ COMMAND = '{{ server_executable }}'
 ARGS = [{% for part in server_command_args %}'{{part}}',{% endfor %}]
 HERE = Path(__file__).parent
 
-os.chdir(str(HERE))
-env = os.environ
-#: Help Jupyter ignore other .jupyter config paths
-env["JUPYTER_PREFER_ENVIRONMENT_OVER_USER"] = "1"
-#: Silence warning about frozen modules
-env["PYDEVD_DISABLE_FILE_VALIDATION"]="1"
-# Set app data location for the electron configuration settings
 appdata = Path(sys.prefix) / "etc"
 appdata.mkdir(exist_ok=True)
-env["widgetron_appdata"] = str(appdata)
+
+os.chdir(str(HERE))
+env = os.environ
+
+env.update(
+    JUPYTER_PREFER_ENVIRONMENT_OVER_USER="1",  # Help Jupyter ignore other .jupyter config paths
+    PYDEVD_DISABLE_FILE_VALIDATION="1",  # Silence warning about frozen modules
+    WIDGETRON_APPDATA=str(appdata),  # Set appdata location for the electron configuration settings
+)
 
 SYS = platform.uname().system
 if SYS == "Windows":
@@ -85,7 +86,7 @@ def main():
     server = Server()
 
     url = f"http://localhost:{server.port}/lab/tree/{FILENAME}?token={server.token}"
-    env["widgetron_url"] = url
+    env["WIDGETRON_URL"] = url
 
     # open UI
     if SYS == "Darwin":


### PR DESCRIPTION
- Adds license info to sbom
- diverts electron config files to be stored within the conda environment's `etc` directory in order to fix an `rmpath` warning on uninstallation